### PR TITLE
Remove the need for getters and setters from demo and use immutable operations

### DIFF
--- a/rotation-service/index.mjs
+++ b/rotation-service/index.mjs
@@ -46,7 +46,7 @@ export const handler = async (event) => {
     }),
   };
 
-  await client.items.put(newItem);
+  await client.items.put(updatedItem);
 
   const response = {
     statusCode: 200,

--- a/rotation-service/index.mjs
+++ b/rotation-service/index.mjs
@@ -30,13 +30,13 @@ export const handler = async (event) => {
   twilioClient.keys(rolledKeySID).remove();
 
   const newAPIKey = await newAPIKeyRequest;
-  const newRolledKeySID = item.fields.find(f => f.title == "sid").value
+  const previousKeySID = item.fields.find(f => f.title == "sid").value
 
   let updatedItem = {
     ...item,
     fields: item.fields.map((f) => {
       if (f.title == "rolledKeySID") {
-        return { ...f, value: newRolledKeySID};
+        return { ...f, value: previousKeySID};
       } else if (f.title == "sid") {
         return { ...f, value: newAPIKey.sid};
       } else if (f.title == "secret") {

--- a/rotation-service/index.mjs
+++ b/rotation-service/index.mjs
@@ -30,12 +30,13 @@ export const handler = async (event) => {
   twilioClient.keys(rolledKeySID).remove();
 
   const newAPIKey = await newAPIKeyRequest;
+  const newRolledKeySID = item.fields.find(f => f.title == "sid").value
 
   let updatedItem = {
     ...item,
     fields: item.fields.map((f) => {
       if (f.title == "rolledKeySID") {
-        return { ...f, value: item.fields.find(f => f.title == "sid").value};
+        return { ...f, value: newRolledKeySID};
       } else if (f.title == "sid") {
         return { ...f, value: newAPIKey.sid};
       } else if (f.title == "secret") {

--- a/rotation-service/index.mjs
+++ b/rotation-service/index.mjs
@@ -31,7 +31,7 @@ export const handler = async (event) => {
 
   const newAPIKey = await newAPIKeyRequest;
 
-  let newItem = {
+  let updatedItem = {
     ...item,
     fields: item.fields.map((f) => {
       if (f.title == "rolledKeySID") {


### PR DESCRIPTION
This PR leaves out defining the `setField` and `getField` helper functions and uses immutable iterator functions to achieve the same result.